### PR TITLE
Migrate to Binance API

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,7 @@ The application configuration files are placed in `src/js/config/` folder:
 
     To obtain cryptocurrency identifier (the `id` property), proceed to [`fetch-currencies.js`](../src/js/files/fetch-currencies.js) file.
 
-    You might also want to read [Coingecko API Documentation](https://www.coingecko.com/en/api/documentation).
+    You might also want to read [Binance API V3 (Spot) Documentation](https://binance-docs.github.io/apidocs/spot/en).
 
 - [`exchanger.js`](../src/js/config/exchanger.js) contains a data for **Exchanger** page logic, including data to connect to Telegram.
 

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -21,15 +21,15 @@ The project code is split into separate JS files to simlify development:
 
 - [`app.js`](../src/js/app.js) - application entry point. Every module is imported here in order be run with application.
 
-- [`script.js`](../src/js/files/script.js) - a module for **Home** page logic. Includes a cryptocurrency fetch from API.
+- [`script.js`](../src/js/files/script.js) - a module for **Home** page logic. Includes a cryptocurrency fetch from API for **Home page**.
 
-- [`fetch-currencies.js`](../src/js/files/fetch-currencies.js) - includes a `loadCryptos()` function to fetch the currencies from the **Coingecko API V3**. Also includes cryptocurrency data and settings for `$.ajax()`
+- [`fetch-currencies.js`](../src/js/files/fetch-currencies.js) - includes a `loadCryptos()` function to fetch the currencies from the **Binance API V3 (Spot)**. Also includes cryptocurrency data and settings for `$.ajax()`
 
     Used at **Exchanger** page.
 
     The `settings` object is shared with [`script.js`](../src/js/files/script.js) `$.ajax()` call, which also loads the cryptocurrencies, but at **Home** page.
 
-    You might also want to read [Coingecko API Documentation](https://www.coingecko.com/en/api/documentation).
+    You might also want to read [Binance API V3 (Spot) Documentation](https://binance-docs.github.io/apidocs/spot/en).
 
 - [`page-load.js`](../src/js/files/exchanger/page-load.js) - a module to bootstrap **Exchanger** page.
 

--- a/src/js/files/exchanger/model/util.js
+++ b/src/js/files/exchanger/model/util.js
@@ -31,6 +31,24 @@ export function isCurrency(currency) {
 }
 
 /**
+ * @typedef {import('../../fetch-currencies.js').currencyPartial} currencyDataPartial
+ */
+
+/**
+ * Indicates if {@link currencyPartial currencyPartial parameter} is {@link currencyDataPartial} (without `price` property).
+ * @param {any} currencyPartial An object to test.
+ * @returns `true` if {@link currencyPartial currencyPartial parameter} is {@link currencyDataPartial}.
+ */
+export function isPartialCurrency(currencyPartial) {
+  return (
+    typeof currencyPartial === 'object' &&
+    'id' in currencyPartial && typeof currencyPartial.id === 'string' &&
+    'name' in currencyPartial && typeof currencyPartial.name === 'string' &&
+    'short' in currencyPartial && typeof currencyPartial.short === 'string'
+  );
+}
+
+/**
  * Indicates if {@link currencies currencies parameter} is {@link currencyData currency[]}.
  * @param {any} currencies An object to test.
  * @returns `true` if {@link currencies currencies parameter} is {@link currencyData currency[]}.
@@ -104,6 +122,15 @@ function throwIfNot(obj, pred, message) {
  */
 export function throwIfNotACurrency(currency) {
   throwIfNot(currency, isCurrency, 'Expected currency to be a currency.');
+}
+
+/**
+ * Throws an error {@link currencyPartial currencyPartial parameter} is not a {@link currencyDataPartial currencyPartial object}.
+ * 
+ * @param {any} currencyPartial An object to test.
+ */
+export function throwIfNotAPartialCurrency(currencyPartial) {
+  throwIfNot(currencyPartial, isPartialCurrency, 'Expected currencyPartial to be a currencyPartial.');
 }
 
 /**


### PR DESCRIPTION
Migrate to Binance API V3 (Spot).

After migration the project is fetching cryptocurrency symbol ticker prices (in current moment).

Symbols are the cryptocurrency pair names, like `BTCUSDT`, see [Binance API V3 (Spot) Documentation](https://binance-docs.github.io/apidocs/spot/en).